### PR TITLE
[V0.5.3 hotfix] Add support of bone layers / bone groups in blender 3.5.0 and above

### DIFF
--- a/gbfr_import.py
+++ b/gbfr_import.py
@@ -20,7 +20,7 @@ def parse_skeleton(filepath, CurCollection):
 		CurCollection.objects.link(armature_obj)
 		bpy.context.view_layer.objects.active = armature_obj
 		utils_set_mode('EDIT')
-			
+
 		SkelTable = []
 		for n in range(skeleton.BodyLength()): # For bone index in skeleton
 			bone = skeleton.Body(n) # Get the bone's information
@@ -65,7 +65,7 @@ def parse_skeleton(filepath, CurCollection):
 						bone_coll = armature_obj.data.collections[bone_coll_name]
 
 					bone_coll.assign(edit_bone)
-				elif bpy.app.version >= (3, 6, 0):
+				elif bpy.app.version >= (3, 5, 0):
 					layer_idx = None
 					try:
 						layer_idx = int(bone_coll_name[1:], 16)

--- a/gbfr_import.py
+++ b/gbfr_import.py
@@ -73,6 +73,7 @@ def parse_skeleton(filepath, CurCollection):
 						pass
 					if layer_idx == None or layer_idx > 31:
 						layer_idx = 31
+					SkelTable[-1]["Coll_name"] = bone_coll_name
 
 					edit_bone.layers[layer_idx] = True
 
@@ -84,6 +85,14 @@ def parse_skeleton(filepath, CurCollection):
 			pbone.rotation_quaternion = SkelTable[x]["Rot"]
 			pbone.location = SkelTable[x]["Pos"]
 			pbone.scale = SkelTable[x]["Scale"]
+
+			if bpy.app.version >= (3, 5, 0):
+				if SkelTable[x]["Coll_name"] not in armature_obj.pose.bone_groups:
+					bgroup = armature_obj.pose.bone_groups.new(SkelTable[x]["Coll_name"])
+				else:
+					bgroup = armature_obj.pose.bone_groups[SkelTable[x]["Coll_name"]]
+
+				pbone.bone_group = bgroup
 		bpy.ops.pose.armature_apply()
 		utils_set_mode('OBJECT')
 		

--- a/gbfr_import.py
+++ b/gbfr_import.py
@@ -57,12 +57,24 @@ def parse_skeleton(filepath, CurCollection):
 					bone_coll_name = Unk.to_bytes(4, "big").decode("ASCII").rstrip('\x00')
 				except:
 					bone_coll_name = "_z"
-				if bone_coll_name not in armature_obj.data.collections:
-					bone_coll = armature_obj.data.collections.new(bone_coll_name)
-				else:
-					bone_coll = armature_obj.data.collections[bone_coll_name]
-				bone_coll.assign(edit_bone)
 
+				if bpy.app.version >= (4, 0, 0):
+					if bone_coll_name not in armature_obj.data.collections:
+						bone_coll = armature_obj.data.collections.new(bone_coll_name)
+					else:
+						bone_coll = armature_obj.data.collections[bone_coll_name]
+
+					bone_coll.assign(edit_bone)
+				elif bpy.app.version >= (3, 6, 0):
+					layer_idx = None
+					try:
+						layer_idx = int(bone_coll_name[1:], 16)
+					except:
+						pass
+					if layer_idx == None or layer_idx > 31:
+						layer_idx = 31
+
+					edit_bone.layers[layer_idx] = True
 
 		# Pose bones based on the position and rotation stored in .skeleton
 		utils_set_mode('POSE')


### PR DESCRIPTION
Add support of bone layers / bone groups in blender 3.5.0 and above (not included blender 4.0.0 and above)
Add version checking for bone collecations support (only support blender 4.0.0 and above)