### PR TITLE
v0.5.4 fixes - bone groups and normals

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Granblue Fantasy Relink Blender Tools",
     "author": "WistfulHopes & AlphaSatanOmega",
-    "version": (0, 5, 1),
+    "version": (0, 5, 4),
     "blender": (3, 5, 0),
     "location": "File > Import/Export | View 3D > Tool Shelf > GBFR",
     "description": "Tool to import & export models from Granblue Fantasy Relink",


### PR DESCRIPTION
* Fixed support for blender versions < 4.0
* Fixes by @Rurires:
  * Normals no longer flipped on export
  * Faces should now be properly be sorted by materials
  * Vertices should now be properly unhidden on export *Actually updated the add-on's version number this time