### PR TITLE
Material indices overhaul

### DIFF
--- a/Entities/MInfo_Converter.py
+++ b/Entities/MInfo_Converter.py
@@ -31,7 +31,10 @@ def replace_mesh_info(flatc_json, blender_json):
     # Replace the BonesToWeightIndices list with the blender export list
     flatc_json_data["BonesToWeightIndices"] = blender_json_data["BonesToWeightIndices"]
 
-    # Submeshes
+    # Replace Submeshes
+    flatc_json_data["SubMeshes"] = blender_json_data["SubMeshes"]
+
+    """
     # Get submesh names
     blender_json_submesh_names = blender_json_data["SubMeshes"]
     flatc_json_submesh_names = []
@@ -44,6 +47,7 @@ def replace_mesh_info(flatc_json, blender_json):
             new_submesh = copy.deepcopy(flatc_json_data["SubMeshes"][-1])
             new_submesh["Name"] = blender_submesh_name
             flatc_json_data["SubMeshes"].append(new_submesh)
+    """
 
     return json.dumps(flatc_json_data, indent=2) # Convert and return
 

--- a/gbfr_import.py
+++ b/gbfr_import.py
@@ -258,8 +258,10 @@ def read_some_data(context, filepath, import_scale):
 			chunk = LOD.Chunks(j)
 			if chunk.SubMesh() != i:
 				continue
-			mat = bpy.data.materials.new(name=sub_mesh.Name().decode() + "." + str(chunk.Material()))
+			mat_name = sub_mesh.Name().decode() + "#" + str(chunk.Material())
+			mat = bpy.data.materials.new(name=mat_name)
 			obj.data.materials.append(mat)
+			mat["MaterialID"] = chunk.Material() # Add material ID as custom property
 
 			chunk_offset = chunk.Offset() // 3
 			chunk_count = chunk.Count() // 3
@@ -280,6 +282,10 @@ def read_some_data(context, filepath, import_scale):
 					pass
 			
 			mat_counter += 1
+
+	# Store mat order in custom property on armature
+	mat_order = [mat.name for mat in obj.data.materials]
+	armature["material_order"] = mat_order
 		
 	if armature is not None:
 		ArmMod = obj.modifiers.new("Armature","ARMATURE")

--- a/utils.py
+++ b/utils.py
@@ -171,6 +171,16 @@ def utils_separate_by_materials(context):
 # then by reverse numberically of the next 2 characters, then lastly by .# index at the end
 def utils_reorder_materials(context):
 	mesh_name = context.active_object.name
+	armature = context.active_object.find_armature()
+
+	if "material_order" in armature:
+		material_order = armature["material_order"]
+	else:
+		raise UserWarning(
+			format_exception("No imported material order stored for this model, unable to sort.")
+		)
+	
+
 	utils_separate_by_materials(context) #Separate by materials first to give the neshes their material names
 
 	# Get meshes
@@ -226,6 +236,7 @@ def utils_select_0_weight_vertices(mesh):
 	zero_weight_vert_count = 0
 	utils_set_mode('EDIT')
 	bpy.ops.mesh.select_mode(type="VERT")
+	bpy.ops.mesh.reveal(select=False) # Unhide all vertices
 	bpy.ops.mesh.select_all(action='DESELECT')
 	mesh_data = mesh.data
 	utils_set_mode('OBJECT') # Funny blender only allows object mode selection :)
@@ -247,4 +258,4 @@ def utils_limit_and_normalize_weights(mesh):
 		# limit total weights to 4
 		bpy.ops.object.vertex_group_limit_total(group_select_mode='ALL', limit=4)
 		# normalize all weights
-		bpy.ops.object.vertex_group_normalize_all(group_select_mode='ALL')
+		bpy.ops.object.vertex_group_normalize_all(group_select_mode='ALL', lock_active=False)


### PR DESCRIPTION
Additions & Changes:
* Added menu to GBFR Tool shelf panel to control material indices.
* Materials no longer have to be sorted in their original order for exporting.
* Material indices are now imported as custom properties on materials
* Missing or invalid Material indices will print human-readable errors
* Imported Material naming scheme now changed to "<MaterialName>#<MaterialIndex>" (e.g. "common#0").
	* This avoids blender overriding the material index number of the name when a duplicate material name exists.
* Errors should be less gargantuan in size now

Fixes:
* Mesh and Armature objects are now unhidden on export
* Fixed limit and normalize weights button and on export not normalizing all weights

Removed:
* Removed sort materials button