### PR TITLE
Blender import moment

### DIFF
--- a/gbfr_panel.py
+++ b/gbfr_panel.py
@@ -1,4 +1,5 @@
 import bpy
+import bpy.utils.previews # Funny blender at it again acting weird for some by not importing this despite bpy being imported :)))))))))))))))))))))
 import os
 import webbrowser
 import urllib.request


### PR DESCRIPTION
Blender apparently doesn't import bpy.utils.previews despite everything else part of bpy being imported when calling "import bpy"